### PR TITLE
Check compressed file type

### DIFF
--- a/yaz0dec.cpp
+++ b/yaz0dec.cpp
@@ -139,7 +139,6 @@ void decodeAll(u8 * src, int srcSize, char* srcName)
       //sprintf_s(dstName, "%s.baa", rawname.c_str(), readBytes - 8);
     else if (fullname.find(".szs") == std::string::npos)
     {
-        printf("no .szs extention detected");
         std::string newOldFile(srcName);
         strcat(srcName, ".szs");
         rename(newOldFile.c_str(), srcName);


### PR DESCRIPTION
Yaz0dec now checks a compressed file's subheader for it's file type. It knows RARC, NARC, U8, kcl, BNTX, msbt, ffnt, BRES, and baa files. If Yaz0dec recognizes the header, it will output the decompressed file with the appropriate extension. If it doesn't, it will either take the SZS off the end of the decompressed file. If the compressed file doesn't end in SZS, it will rename the compressed file to add a SZS extension on the end first.